### PR TITLE
channel colors

### DIFF
--- a/src/app/channel-area/channel-area.component.html
+++ b/src/app/channel-area/channel-area.component.html
@@ -60,8 +60,21 @@
 
         
     </div>
+  
     
-  <div class="messages">
+
+  <div class="form-group mt-3">
+    <label for="channelBgColor">Channel Background Color:</label>
+    <input 
+      type="color"
+      id="channelBgColor"
+      [value]="channelBackgroundColor"
+      (change)="onChannelColorChange($event)"
+      class="form-control form-control-color mt-2"
+    />
+  </div>    
+  <div class="messages"
+  [ngStyle]="{ 'background-color': channelBackgroundColor }">
     <div *ngFor="let msg of messages" class="message-bubble">
       <strong>
         {{ msg.sender }} 

--- a/src/app/channel-area/channel-area.component.ts
+++ b/src/app/channel-area/channel-area.component.ts
@@ -36,6 +36,8 @@ export class ChannelAreaComponent implements OnInit {
     isAdmin: false
   };
 
+  channelBackgroundColors: { [channelName: string]: string } = {};
+
   showEmojiPicker: boolean = false;
   pendingInvites: string[] = [];
 
@@ -47,6 +49,11 @@ export class ChannelAreaComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
+
+    const savedColors = localStorage.getItem('channelBgColors');
+    if (savedColors) {
+      this.channelBackgroundColors = JSON.parse(savedColors);
+    }
 
     this.auth.onAuthStateChanged((user) => {
       if (user) {
@@ -133,6 +140,20 @@ export class ChannelAreaComponent implements OnInit {
   
   
   //alexia add
+
+  get channelBackgroundColor(): string {
+    return this.channelName && this.channelBackgroundColors[this.channelName]
+      ? this.channelBackgroundColors[this.channelName]
+      : '#ffffff';
+  }
+  
+  onChannelColorChange(event: Event): void {
+    const color = (event.target as HTMLInputElement).value;
+    if (this.channelName) {
+      this.channelBackgroundColors[this.channelName] = color;
+      localStorage.setItem('channelBgColors', JSON.stringify(this.channelBackgroundColors));
+    }
+  }
 
   toggleEmojiPicker(): void {
     this.showEmojiPicker = !this.showEmojiPicker;


### PR DESCRIPTION
-Users can select a custom background color for each channel's chat area.
-A color picker is shown in the channel UI to let users choose.
-Color is saved per channel, using channelName as the unique key.
-The color choice is stored, so it stays even after logout or page refresh.